### PR TITLE
enable all petitionemail extensions to play together

### DIFF
--- a/js/petitionemailsingle.js
+++ b/js/petitionemailsingle.js
@@ -1,0 +1,37 @@
+(function($){
+  // Handle display of recipient email options.
+  // Get the field controlling which option to use.
+  CRM.api3('CustomField', 'getsingle', {
+    "return": ["id"],
+    "name": "Email_Recipient_System"
+  }).done(function(recipientSystemField) {
+    // Set based on initial value.
+    update_single_recipient_display(recipientSystemField.id);
+    // Update when the value changes.
+    CRM.$("select[id*='custom_" + recipientSystemField.id + "']").change(function() {;
+      update_single_recipient_display(recipientSystemField.id);
+    });
+  });
+})(CRM.$);
+
+function update_single_recipient_display(fieldId){
+  // Update display based on selected value.
+  CRM.api3('CustomField', 'get', {
+      "sequential": 1,
+      "return": ["id"],
+      "name": {'IN': ['Recipient_Name', 'Recipient_Email']},
+  }).done(function(recipientFields) {
+    // Iterate over both the name and email fields.
+    var selectedRecipientSystem = CRM.$("select[id*='custom_" + fieldId + "'] option:selected").val();
+    if (selectedRecipientSystem == 'Single') {
+      CRM.$(recipientFields.values).each(function(){
+        CRM.$("tr[class*='custom_" + this.id + "']").show();
+      });
+    }
+    else {
+      CRM.$(recipientFields.values).each(function(){
+        CRM.$("tr[class*='custom_" + this.id + "']").hide();
+      });
+    }
+  });
+}

--- a/petitionemail.php
+++ b/petitionemail.php
@@ -152,6 +152,12 @@ function petitionemail_civicrm_buildForm($formName, &$form) {
       // TODO: add js for picking message field.
       CRM_Core_Resources::singleton()->addScriptFile('com.aghstrategies.petitionemail', 'js/messageField.js');
       // TODO: make sure it shows survey custom fields.
+      break;
+
+    case 'CRM_Custom_Form_CustomDataByType':
+      CRM_Core_Resources::singleton()->addScriptFile('com.aghstrategies.petitionemail', 'js/petitionemailsingle.js');
+      break;
+
   }
 }
 


### PR DESCRIPTION
This is an initial change that will go with changes to the other
petitionemail extensions allowing them to co-exist more easily.

It essentially makes it each extensions job to either display their
recipient fields or hide them.

Previously each extension has to hide the single recipient field.

Now, the main petitionemail extension takes care of that job.